### PR TITLE
Wrap only included component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ export const whyDidYouUpdate = (React, opts = {}) => {
     let ctor = type;
 
     // the element is a class component or a functional component
-    if (typeof ctor === 'function') {
+    if (typeof ctor === 'function' && shouldInclude(getDisplayName(ctor), opts)) {
       if (ctor.prototype && typeof ctor.prototype.render === 'function') {
          // If the constructor has a `render` method in its prototype,
         // we're dealing with a class component

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,6 @@ function createComponentDidUpdate (opts) {
   return function componentDidUpdate (prevProps, prevState) {
     const displayName = getDisplayName(this.constructor);
 
-    if (!shouldInclude(displayName, opts)) {
-      return
-    }
-
     const propsDiff = classifyDiff(prevProps, this.props, `${displayName}.props`)
     if (propsDiff.type === DIFF_TYPES.UNAVOIDABLE) {
       return

--- a/tests/wrapper-test.js
+++ b/tests/wrapper-test.js
@@ -182,6 +182,58 @@ describe(`whyDidYouUpdate wrapper`, () => {
     equal(groupStore.entries[0][0], `Stub`)
   })
 
+  it(`skip wrapping certain names using a regexp`, () => {
+    whyDidYouUpdate(React, {exclude: /Stub/})
+
+    class Foo extends React.Component {
+      render () {
+        return <noscript />
+      }
+    }
+
+    equal(React.createElement(Stub).type.name, 'Stub')
+    equal(React.createElement(Foo).type.name, 'WDYUClassComponent')
+  })
+
+  it(`skip wrapping certain names using a string`, () => {
+    whyDidYouUpdate(React, {exclude: 'Stub'})
+
+    class Foo extends React.Component {
+      render () {
+        return <noscript />
+      }
+    }
+
+    equal(React.createElement(Stub).type.name, 'Stub')
+    equal(React.createElement(Foo).type.name, 'WDYUClassComponent')
+  })
+
+  it(`only wrap certain names using a regexp`, () => {
+    whyDidYouUpdate(React, {include: /Stub/})
+
+    class Foo extends React.Component {
+      render () {
+        return <noscript />
+      }
+    }
+
+    equal(React.createElement(Stub).type.name, 'WDYUClassComponent')
+    equal(React.createElement(Foo).type.name, 'Foo')
+  })
+
+  it(`only wrap certain names using a string`, () => {
+    whyDidYouUpdate(React, {include: 'Stub'})
+
+    class Foo extends React.Component {
+      render () {
+        return <noscript />
+      }
+    }
+
+    equal(React.createElement(Stub).type.name, 'WDYUClassComponent')
+    equal(React.createElement(Foo).type.name, 'Foo')
+  })
+
   it(`still calls the original componentDidUpdate for class component`, done => {
     whyDidYouUpdate(React)
 


### PR DESCRIPTION
Some component does not play wall when they are wrapped. For example reach-router need to have its Redirect untouched when used in a Router.

This PR change the way include and exclude behave. Instead of doing filter (through shouldInclude) at runtime (inside componentDidUpdate), filtering is done at component initialization. Components that should not be included are not wrapped.